### PR TITLE
chore: update x16emu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,6 @@ gen: cmd/gen/*.go
 
 .PHONY: x16emu
 x16emu:
-	docker build -t paulforgey/x16emu x16emu
+	docker buildx create --use
+	docker buildx build --load --platform linux/amd64 -t paulforgey/x16emu x16emu
 

--- a/x16emu/Dockerfile
+++ b/x16emu/Dockerfile
@@ -4,9 +4,9 @@ RUN apt-get update \
 	&& apt-get install -y unzip \
 	&& apt-get install -y libsdl2-dev
 
-ADD https://github.com/X16Community/x16-emulator/releases/download/r47/x16emu_linux-x86_64-r47.zip /
+ADD https://github.com/X16Community/x16-emulator/releases/download/r48/x16emu_linux-x86_64-r48.zip /
 
-RUN unzip x16emu_linux-x86_64-r47.zip
+RUN unzip x16emu_linux-x86_64-r48.zip
 
 ENV SDL_VIDEODRIVER=dummy
 ENV SDL_AUDIODRIVER=dummy


### PR DESCRIPTION
use r48
use buildx to build amd64 version regardless who builds docker image